### PR TITLE
docs: log Phase B freeze prep in DEV_NOTES

### DIFF
--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -1,4 +1,18 @@
-# 2025-05-09  Cleanup
+
+# 2025-05-12 — Phase B hard-freeze preparations
+
+- **Docs sync**: README, `docs/plan.md`, and `lakehouse-book/00_project_plan.md` now share the same BEGIN/END exit-criteria block.  
+- **DevContainer**: Dockerfile ships Node 18, `markdownlint-cli 0.40.0`, and GitHub CLI; `devcontainer.json` switched to the built image (`ghcr.io/.../lakehouse-code:latest`).  
+- **Pre-commit**: Node 18 is used as system runtime; gitlint/markdownlint/vale all pass.  
+- **Guard CI**:  
+  - `guard-pr` (label gate) unchanged.  
+  - New `guard-main` job runs on every push to **main**.  
+  - Main branch now shows three consecutive green runs (Exit #3).  
+- **Smoke CI**: Added `push@main` trigger and `timeout-minutes: 20`.  
+- **Roadmap**: Timeline bumped to **Sprint S-1** (AWS Serverless “≤ 30 min deploy”).  
+- **Next steps**: push the `phase-b-complete` tag + release, then start `feat/s1-serverless-deploy`.
+
+# 2025-05-09 Cleanup
 
 - Removed legacy workflows: build-push.yml, ci.yml
 


### PR DESCRIPTION
Adds a summary of today’s work:
* Doc sync across three files
* DevContainer image with Node 18 + markdownlint + gh
* guard-main job (push@main) and 3× green streak
* Smoke workflow push trigger + timeout
* Roadmap moved to Sprint S-1 Next tasks: push phase-b-complete tag and start serverless deploy.