### PR TITLE
feat (tf): add terraform workflow for CI/CD

### DIFF
--- a/.github/workflows/ci_guard.yml
+++ b/.github/workflows/ci_guard.yml
@@ -1,70 +1,56 @@
 # ====================================================================
 # File: .github/workflows/ci_guard.yml
-# Purpose: One-job guard – PR gated by labels, main always runs
+# Purpose: Lightweight guard – always runs on PR/push
 # ====================================================================
 
 name: ci_guard
 
-on:
-  pull_request:
-    types: [opened, synchronize, labeled, reopened]
-  push:
-    branches: [ main ]
+on: [push, pull_request]      # no label gating
 
+permissions:
+  contents: read
+
+# ---------------------------------------------------------------
+# Job 1: Terraform fmt / validate / plan
+# (thin wrapper around official starter-workflow copy)
+# ---------------------------------------------------------------
 jobs:
-  iac-guard:
-    # ---------------------------------------------------------------
-    # Job condition:
-    #   • push  → always run
-    #   • pull_request → run only if both required labels are present
-    # ---------------------------------------------------------------
-    if: |
-      github.event_name == 'push' ||
-      (
-        github.event_name == 'pull_request' &&
-        contains(join(github.event.pull_request.labels.*.name, ','), 'environment:') &&
-        contains(join(github.event.pull_request.labels.*.name, ','), 'norm:')
-      )
-    runs-on: ubuntu-latest
+  terraform-checks:
+    uses: ./ci/workflows/terraform.yml   # official template (thin-customised)
+    with:
+      path: infra                        # default, overrideable
 
+# ---------------------------------------------------------------
+# Job 2: IaC linters & security (tflint + tfsec)
+# ---------------------------------------------------------------
+  security:
+    needs: terraform-checks
+    runs-on: ubuntu-latest
     steps:
-    # --- Common setup ---------------------------------------------
       - uses: actions/checkout@v4
 
-      - uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: 1.11.4       # stable as of 2025-05
-
+      # tflint
       - uses: terraform-linters/setup-tflint@v1
         with:
-          tflint_version: v0.51.1         # latest as of 2025-05
-
-    # --- Common IaC checks ----------------------------------------
-      - name: terraform fmt (check)
-        run: terraform fmt -recursive -check
-
-      - name: terraform validate
-        run: terraform init -backend=false && terraform validate
-
-      - name: tflint
-        run: |
+          tflint_version: v0.51.1        # latest 2025-05
+      - run: |
           tflint --init
           tflint
 
-      - uses: aquasecurity/tfsec-action@v1.0.1
+      # tfsec (soft-fail for learning)
+      - uses: aquasecurity/tfsec-action@v1
         with:
-          version: latest                 # always download latest tfsec CLI
           additional_args: --config-file .tfsec.yml --soft-fail
 
-    # --- main-only steps ------------------------------------------
-      - name: Generate SBOM (stub)
-        if: github.event_name == 'push'
-        run: echo "Syft SBOM generation stub"
+# ---------------------------------------------------------------
+# Job 3: SBOM & Great Expectations stubs (push only)
+# ---------------------------------------------------------------
+  sbom:
+    if: github.event_name == 'push'      # skip on PRs
+    needs: security
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Syft SBOM generation stub"
+      - run: echo "cosign sign stub"
+      - run: echo "Great Expectations contract stub"
 
-      - name: Sign SBOM with cosign (stub)
-        if: github.event_name == 'push'
-        run: echo "cosign sign stub"
-
-      - name: Great Expectations data contract (stub)
-        if: github.event_name == 'push'
-        run: echo "GE contract check stub"

--- a/.github/workflows/ci_infracost.yml
+++ b/.github/workflows/ci_infracost.yml
@@ -10,27 +10,23 @@ on:
     paths: [ "**/*.tf", ".github/workflows/ci-deploy.yml" ]
 
 jobs:
-  infracost-diff:
+  infracost:
+    # needs write permission to post PR comments
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
 
-      - uses: infracost/actions/setup@v2
+      # Official Infracost starter workflow:
+      # * installs the CLI
+      # * runs breakdown & diff
+      # * posts/updates GitHub PR comment
+      - uses: infracost/actions/diff@v2
         with:
-          api-key: ${{ secrets.INFRACOST_API_KEY }}
-
-      - name: Breakdown
-        run: |
-          infracost breakdown --path=infra \
-            --format=json \
-            --out-file=/tmp/infracost.json
-
-      - name: Post cost comment
-        if: github.event_name == 'pull_request'
-        run: |
-          infracost comment github \
-            --path=/tmp/infracost.json \
-            --behavior=update \
-            --repo=${{ github.repository }} \
-            --pull-request=${{ github.event.pull_request.number }} \
-            --github-token=${{ github.token }}
+          path: infra               # root directory containing *.tf files
+          format: github-comment    # update existing comment or create new
+        env:
+          INFRACOST_API_KEY: ${{ secrets.INFRACOST_API_KEY }}

--- a/.github/workflows/ci_plan_apply.yml
+++ b/.github/workflows/ci_plan_apply.yml
@@ -1,71 +1,46 @@
 name: ci_plan_apply
 
-# Manual trigger and automatic trigger on pushes to main
 on:
   workflow_dispatch:
   push:
     branches: [main]
 
 jobs:
-  apply:
+  oidc:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
-
     permissions:
-      id-token: write        # allow OIDC token retrieval
-      contents: read         # checkout needs this (defaults to read)
-
+      id-token: write
+      contents: read
     env:
       AWS_REGION:  ${{ vars.AWS_REGION || 'us-east-1' }}
-      STATE_BUCKET: ${{ vars.STATE_BUCKET }}
-      LOCK_TABLE:   ${{ vars.LOCK_TABLE }}
-      TF_VAR_budget_email: ${{ secrets.BUDGET_EMAIL }}
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      # --- OIDC → AssumeRole ---
+      # OIDC credential
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
-          aws-region: ${{ env.AWS_REGION || 'us-east-1' }}
+          aws-region: ${{ env.AWS_REGION }}
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+  # --- apply via reusable workflow (dev → prod) ------------------
+  apply-dev:
+    needs: oidc
+    uses: ./ci/workflows/terraform_apply.yml
+    with:
+      bucket:      ${{ vars.STATE_BUCKET }}
+      state_key:   ci/terraform.tfstate
+      lock_table:  ${{ vars.LOCK_TABLE }}
+      workspace:   dev
+      extra_var:   env=dev
 
-      # -------- CI workspace cleanup --------
-      - name: Destroy CI workspace (best-effort)
-        if: github.event_name == 'pull_request'
-        continue-on-error: true
-        run: |
-          cd infra
-          terraform init -input=false \
-            -backend-config="bucket=${STATE_BUCKET}" \
-            -backend-config="key=ci/terraform.tfstate" \
-            -backend-config="region=${AWS_REGION}" \
-            -backend-config="dynamodb_table=${LOCK_TABLE}"
-          terraform workspace select ci || terraform workspace new ci
-          terraform destroy -auto-approve -input=false
-
-      # -------- Prod apply (main branch) ----
-      - name: Terraform apply prod
-        if: github.ref == 'refs/heads/main'
-        run: |
-          cd infra
-          terraform init -input=false \
-            -backend-config="bucket=${STATE_BUCKET}" \
-            -backend-config="key=ci/terraform.tfstate" \
-            -backend-config="region=${AWS_REGION}" \
-            -backend-config="dynamodb_table=${LOCK_TABLE}"
-          terraform workspace select prod || terraform workspace new prod
-          start=$(date +%s)
-          terraform apply -auto-approve -input=false -var="env=prod"
-          echo "{\"runtime_sec\":$(( $(date +%s)-start ))}" > /tmp/stopwatch.json
-
-      - name: Upload stopwatch artifact
-        uses: actions/upload-artifact@v4
-        if: github.ref == 'refs/heads/main'
-        with:
-          name: stopwatch
-          path: /tmp/stopwatch.json
+  apply-prod:
+    needs: apply-dev
+    if: github.ref == 'refs/heads/main'
+    uses: ./ci/workflows/terraform_apply.yml
+    with:
+      bucket:      ${{ vars.STATE_BUCKET }}
+      state_key:   prod/terraform.tfstate
+      lock_table:  ${{ vars.LOCK_TABLE }}
+      workspace:   prod
+      extra_var:   env=prod

--- a/.github/workflows/ci_smoke.yml
+++ b/.github/workflows/ci_smoke.yml
@@ -15,9 +15,6 @@ on:
 
 jobs:
   smoke-ci:
-    # allow skipping via label “skip-smoke”
-    if: github.event_name != 'pull_request' ||
-        !contains(join(github.event.pull_request.labels.*.name, ','), 'skip-smoke')
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -25,9 +22,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run quick_start smoke
-        run: |
-          chmod +x ./scripts/quick_start.sh
-          ./scripts/quick_start.sh --smoke --local-mode
+        run: bash scripts/quick_start.sh --smoke --local-mode
 
       - name: Smoke summary
         if: always()

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,117 @@
+# This workflow installs the latest version of Terraform CLI and configures the Terraform CLI configuration file
+# with an API token for Terraform Cloud (app.terraform.io). On pull request events, this workflow will run
+# `terraform init`, `terraform fmt`, and `terraform plan` (speculative plan via Terraform Cloud). On push events
+# to the $default-branch branch, `terraform apply` will be executed.
+#
+# Documentation for `hashicorp/setup-terraform` is located here: https://github.com/hashicorp/setup-terraform
+#
+# To use this workflow, you will need to complete the following setup steps.
+#
+# 1. Create a `main.tf` file in the root of this repository with the `remote` backend and one or more resources defined.
+#   Example `main.tf`:
+#     # The configuration for the `remote` backend.
+#     terraform {
+#       backend "remote" {
+#         # The name of your Terraform Cloud organization.
+#         organization = "example-organization"
+#
+#         # The name of the Terraform Cloud workspace to store Terraform state files in.
+#         workspaces {
+#           name = "example-workspace"
+#         }
+#       }
+#     }
+#
+#     # An example resource that does nothing.
+#     resource "null_resource" "example" {
+#       triggers = {
+#         value = "A example resource that does nothing!"
+#       }
+#     }
+#
+#
+# 2. Generate a Terraform Cloud user API token and store it as a GitHub secret (e.g. TF_API_TOKEN) on this repository.
+#   Documentation:
+#     - https://www.terraform.io/docs/cloud/users-teams-organizations/api-tokens.html
+#     - https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets
+#
+# 3. Reference the GitHub secret in step using the `hashicorp/setup-terraform` GitHub Action.
+#   Example:
+#     - name: Setup Terraform
+#       uses: hashicorp/setup-terraform@v1
+#       with:
+#         cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+
+# ------------------------------------------------------------------
+# This file is copied from starter-workflows/deployments/terraform.yml
+# Thin-customised for Starter Lakehouse:
+#   • added workflow_call trigger
+#   • backend=false (local) for safety
+#   • apply step disabled
+# ------------------------------------------------------------------
+
+name: 'Terraform'
+
+# on:
+#  push:
+#    branches: [ $default-branch ]
+#  pull_request:
+
+# reusable workflow trigger
+on:
+  workflow_call:
+    inputs:
+      path:
+        required: false
+        type: string
+        default: infra
+
+permissions:
+  contents: read
+
+jobs:
+  terraform:
+    name: 'Terraform'
+    runs-on: ubuntu-latest
+    # environment: production # this is not needed for this learning exercise
+
+    # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+    # Checkout the repository to the GitHub Actions runner
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
+    - name: Setup Terraform
+    #  uses: hashicorp/setup-terraform@v1
+      uses: hashicorp/setup-terraform@v3
+      with:
+    #    cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+        terraform_version: 1.7.x
+
+    # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
+    - name: Terraform Init
+    #  run: terraform init
+      run: terraform -chdir=${{ inputs.path }} init -backend=false -upgrade # disable backend for safety
+
+    # Checks that all Terraform configuration files adhere to a canonical format
+    - name: Terraform Format
+    #  run: terraform fmt -check
+      run: terraform -chdir=${{ inputs.path }} fmt -check -recursive # check formatting of all files in the path
+
+    # Generates an execution plan for Terraform
+    - name: Terraform Plan
+    #  run: terraform plan -input=false
+      run: terraform -chdir=${{ inputs.path }} plan -no-color
+
+      # On push to $default-branch, build or change infrastructure according to Terraform configuration files
+      # Note: It is recommended to set up a required "strict" status check in your repository for "Terraform Cloud". See the documentation on "strict" required status checks for more information: https://help.github.com/en/github/administering-a-repository/types-of-required-status-checks
+    - name: Terraform Apply
+      # if: github.ref == 'refs/heads/$default-branch' && github.event_name == 'push'
+      # run: terraform apply -auto-approve -input=false
+      if: false # disable apply to Terraform Cloud for safety
+      run: echo "Apply to Terraform Cloud skipped"

--- a/.github/workflows/terraform_apply.yml
+++ b/.github/workflows/terraform_apply.yml
@@ -1,0 +1,29 @@
+# ------------------------------------------------------------------
+# Thin wrapper: init → workspace select → terraform apply
+# ------------------------------------------------------------------
+name: terraform_apply
+
+on:
+  workflow_call:
+    inputs:
+      path:          { type: string,  default: infra }
+      bucket:        { type: string }
+      state_key:     { type: string }
+      lock_table:    { type: string }
+      workspace:     { type: string,  default: prod }
+      extra_var:     { type: string,  default: "" }
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: hashicorp/setup-terraform@v3
+      - name: Init & Apply
+        run: |
+          cd ${{ inputs.path }}
+          terraform init -backend-config="bucket=${{ inputs.bucket }}" \
+                         -backend-config="key=${{ inputs.state_key }}" \
+                         -backend-config="region=${AWS_REGION:-us-east-1}" \
+                         -backend-config="dynamodb_table=${{ inputs.lock_table }}"
+          terraform workspace select ${{ inputs.workspace }} || terraform workspace new ${{ inputs.workspace }}
+          terraform apply -auto-approve -input=false ${{ inputs.extra_var && format('-var=\"{0}\"', inputs.extra_var) }}

--- a/.github/workflows/terraform_fmt_validate.yml
+++ b/.github/workflows/terraform_fmt_validate.yml
@@ -1,0 +1,17 @@
+name: tf_fmt_validate
+on:
+  workflow_call:
+    inputs:
+      path:
+        required: false
+        type: string
+        default: infra
+jobs:
+  fmt_validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with: { terraform_version: 1.7.5 }
+      - run: terraform -chdir=${{ inputs.path }} fmt -check -recursive
+      - run: terraform -chdir=${{ inputs.path }} validate -no-color

--- a/ci/workflows/ci_guard.yml
+++ b/ci/workflows/ci_guard.yml
@@ -1,0 +1,56 @@
+# ====================================================================
+# File: .github/workflows/ci_guard.yml
+# Purpose: Lightweight guard – always runs on PR/push
+# ====================================================================
+
+name: ci_guard
+
+on: [push, pull_request]      # no label gating
+
+permissions:
+  contents: read
+
+# ---------------------------------------------------------------
+# Job 1: Terraform fmt / validate / plan
+# (thin wrapper around official starter-workflow copy)
+# ---------------------------------------------------------------
+jobs:
+  terraform-checks:
+    uses: ./ci/workflows/terraform.yml   # official template (thin-customised)
+    with:
+      path: infra                        # default, overrideable
+
+# ---------------------------------------------------------------
+# Job 2: IaC linters & security (tflint + tfsec)
+# ---------------------------------------------------------------
+  security:
+    needs: terraform-checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # tflint
+      - uses: terraform-linters/setup-tflint@v1
+        with:
+          tflint_version: v0.51.1        # latest 2025-05
+      - run: |
+          tflint --init
+          tflint
+
+      # tfsec (soft-fail for learning)
+      - uses: aquasecurity/tfsec-action@v1
+        with:
+          additional_args: --config-file .tfsec.yml --soft-fail
+
+# ---------------------------------------------------------------
+# Job 3: SBOM & Great Expectations stubs (push only)
+# ---------------------------------------------------------------
+  sbom:
+    if: github.event_name == 'push'      # skip on PRs
+    needs: security
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Syft SBOM generation stub"
+      - run: echo "cosign sign stub"
+      - run: echo "Great Expectations contract stub"
+

--- a/ci/workflows/ci_infracost.yml
+++ b/ci/workflows/ci_infracost.yml
@@ -1,0 +1,32 @@
+# ci_infracost.yml
+
+name: ci_infracost
+
+on:
+  pull_request:
+    paths: [ "**/*.tf", ".github/workflows/ci-deploy.yml" ]
+  push:
+    branches: [ main ]
+    paths: [ "**/*.tf", ".github/workflows/ci-deploy.yml" ]
+
+jobs:
+  infracost:
+    # needs write permission to post PR comments
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Official Infracost starter workflow:
+      # * installs the CLI
+      # * runs breakdown & diff
+      # * posts/updates GitHub PR comment
+      - uses: infracost/actions/diff@v2
+        with:
+          path: infra               # root directory containing *.tf files
+          format: github-comment    # update existing comment or create new
+        env:
+          INFRACOST_API_KEY: ${{ secrets.INFRACOST_API_KEY }}

--- a/ci/workflows/ci_plan_apply.yml
+++ b/ci/workflows/ci_plan_apply.yml
@@ -1,0 +1,46 @@
+name: ci_plan_apply
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+jobs:
+  oidc:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      AWS_REGION:  ${{ vars.AWS_REGION || 'us-east-1' }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # OIDC credential
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+  # --- apply via reusable workflow (dev → prod) ------------------
+  apply-dev:
+    needs: oidc
+    uses: ./ci/workflows/terraform_apply.yml
+    with:
+      bucket:      ${{ vars.STATE_BUCKET }}
+      state_key:   ci/terraform.tfstate
+      lock_table:  ${{ vars.LOCK_TABLE }}
+      workspace:   dev
+      extra_var:   env=dev
+
+  apply-prod:
+    needs: apply-dev
+    if: github.ref == 'refs/heads/main'
+    uses: ./ci/workflows/terraform_apply.yml
+    with:
+      bucket:      ${{ vars.STATE_BUCKET }}
+      state_key:   prod/terraform.tfstate
+      lock_table:  ${{ vars.LOCK_TABLE }}
+      workspace:   prod
+      extra_var:   env=prod

--- a/ci/workflows/ci_smoke.yml
+++ b/ci/workflows/ci_smoke.yml
@@ -1,0 +1,31 @@
+# ====================================================================
+# File: .github/workflows/ci_smoke.yml
+# Purpose: Run quick_start smoke test on local Docker compose
+# ====================================================================
+
+name: ci_smoke
+
+on:
+  push:
+    branches: [ main ]
+    paths: [ 'scripts/quick_start.sh', '**/docker-compose*', 'Makefile' ]
+  pull_request:
+    paths: [ 'scripts/quick_start.sh', '**/docker-compose*', 'Makefile' ]
+  workflow_dispatch:
+
+jobs:
+  smoke-ci:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run quick_start smoke
+        run: bash scripts/quick_start.sh --smoke --local-mode
+
+      - name: Smoke summary
+        if: always()
+        run: |
+          echo "### Smoke Test Result"            >> $GITHUB_STEP_SUMMARY
+          echo "workflow = ${{ github.workflow }}" >> $GITHUB_STEP_SUMMARY

--- a/ci/workflows/terraform.yml
+++ b/ci/workflows/terraform.yml
@@ -1,0 +1,117 @@
+# This workflow installs the latest version of Terraform CLI and configures the Terraform CLI configuration file
+# with an API token for Terraform Cloud (app.terraform.io). On pull request events, this workflow will run
+# `terraform init`, `terraform fmt`, and `terraform plan` (speculative plan via Terraform Cloud). On push events
+# to the $default-branch branch, `terraform apply` will be executed.
+#
+# Documentation for `hashicorp/setup-terraform` is located here: https://github.com/hashicorp/setup-terraform
+#
+# To use this workflow, you will need to complete the following setup steps.
+#
+# 1. Create a `main.tf` file in the root of this repository with the `remote` backend and one or more resources defined.
+#   Example `main.tf`:
+#     # The configuration for the `remote` backend.
+#     terraform {
+#       backend "remote" {
+#         # The name of your Terraform Cloud organization.
+#         organization = "example-organization"
+#
+#         # The name of the Terraform Cloud workspace to store Terraform state files in.
+#         workspaces {
+#           name = "example-workspace"
+#         }
+#       }
+#     }
+#
+#     # An example resource that does nothing.
+#     resource "null_resource" "example" {
+#       triggers = {
+#         value = "A example resource that does nothing!"
+#       }
+#     }
+#
+#
+# 2. Generate a Terraform Cloud user API token and store it as a GitHub secret (e.g. TF_API_TOKEN) on this repository.
+#   Documentation:
+#     - https://www.terraform.io/docs/cloud/users-teams-organizations/api-tokens.html
+#     - https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets
+#
+# 3. Reference the GitHub secret in step using the `hashicorp/setup-terraform` GitHub Action.
+#   Example:
+#     - name: Setup Terraform
+#       uses: hashicorp/setup-terraform@v1
+#       with:
+#         cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+
+# ------------------------------------------------------------------
+# This file is copied from starter-workflows/deployments/terraform.yml
+# Thin-customised for Starter Lakehouse:
+#   • added workflow_call trigger
+#   • backend=false (local) for safety
+#   • apply step disabled
+# ------------------------------------------------------------------
+
+name: 'Terraform'
+
+# on:
+#  push:
+#    branches: [ $default-branch ]
+#  pull_request:
+
+# reusable workflow trigger
+on:
+  workflow_call:
+    inputs:
+      path:
+        required: false
+        type: string
+        default: infra
+
+permissions:
+  contents: read
+
+jobs:
+  terraform:
+    name: 'Terraform'
+    runs-on: ubuntu-latest
+    # environment: production # this is not needed for this learning exercise
+
+    # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+    # Checkout the repository to the GitHub Actions runner
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
+    - name: Setup Terraform
+    #  uses: hashicorp/setup-terraform@v1
+      uses: hashicorp/setup-terraform@v3
+      with:
+    #    cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+        terraform_version: 1.7.x
+
+    # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
+    - name: Terraform Init
+    #  run: terraform init
+      run: terraform -chdir=${{ inputs.path }} init -backend=false -upgrade # disable backend for safety
+
+    # Checks that all Terraform configuration files adhere to a canonical format
+    - name: Terraform Format
+    #  run: terraform fmt -check
+      run: terraform -chdir=${{ inputs.path }} fmt -check -recursive # check formatting of all files in the path
+
+    # Generates an execution plan for Terraform
+    - name: Terraform Plan
+    #  run: terraform plan -input=false
+      run: terraform -chdir=${{ inputs.path }} plan -no-color
+
+      # On push to $default-branch, build or change infrastructure according to Terraform configuration files
+      # Note: It is recommended to set up a required "strict" status check in your repository for "Terraform Cloud". See the documentation on "strict" required status checks for more information: https://help.github.com/en/github/administering-a-repository/types-of-required-status-checks
+    - name: Terraform Apply
+      # if: github.ref == 'refs/heads/$default-branch' && github.event_name == 'push'
+      # run: terraform apply -auto-approve -input=false
+      if: false # disable apply to Terraform Cloud for safety
+      run: echo "Apply to Terraform Cloud skipped"

--- a/ci/workflows/terraform_apply.yml
+++ b/ci/workflows/terraform_apply.yml
@@ -1,0 +1,29 @@
+# ------------------------------------------------------------------
+# Thin wrapper: init → workspace select → terraform apply
+# ------------------------------------------------------------------
+name: terraform_apply
+
+on:
+  workflow_call:
+    inputs:
+      path:          { type: string,  default: infra }
+      bucket:        { type: string }
+      state_key:     { type: string }
+      lock_table:    { type: string }
+      workspace:     { type: string,  default: prod }
+      extra_var:     { type: string,  default: "" }
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: hashicorp/setup-terraform@v3
+      - name: Init & Apply
+        run: |
+          cd ${{ inputs.path }}
+          terraform init -backend-config="bucket=${{ inputs.bucket }}" \
+                         -backend-config="key=${{ inputs.state_key }}" \
+                         -backend-config="region=${AWS_REGION:-us-east-1}" \
+                         -backend-config="dynamodb_table=${{ inputs.lock_table }}"
+          terraform workspace select ${{ inputs.workspace }} || terraform workspace new ${{ inputs.workspace }}
+          terraform apply -auto-approve -input=false ${{ inputs.extra_var && format('-var=\"{0}\"', inputs.extra_var) }}


### PR DESCRIPTION
* Add terraform workflow for CI/CD
* This commit introduces a new GitHub Actions workflow from GitHub's official template for Terraform. The workflow is designed to for Terraform to automate the CI/CD process.

# Checklist

- [ ] File names follow the snake_case convention (`ci_*.yml`, scripts, etc.).
- [ ] `pre-commit run --all-files` passes.
- [ ] Docs updated (`README`, `project-plan.md`) if paths changed.
